### PR TITLE
using prop-types components instead of deprecated React.PropType

### DIFF
--- a/Vimeo.ios.js
+++ b/Vimeo.ios.js
@@ -6,6 +6,7 @@ import React from 'react';
 import {
   StyleSheet
 } from 'react-native';
+import PropTypes from 'prop-types';
 import WebViewBridge from 'react-native-webview-bridge';
 
 
@@ -17,13 +18,13 @@ function getVimeoPageURL(videoId) {
 export default class Vimeo extends React.Component {
 
   static propTypes = {
-    videoId: React.PropTypes.string.isRequired,
-    onReady: React.PropTypes.func,
-    onPlay: React.PropTypes.func,
-    onPlayProgress: React.PropTypes.func,
-    onPause: React.PropTypes.func,
-    onFinish: React.PropTypes.func,
-    scalesPageToFit: React.PropTypes.bool
+    videoId: PropTypes.string.isRequired,
+    onReady: PropTypes.func,
+    onPlay: PropTypes.func,
+    onPlayProgress: PropTypes.func,
+    onPause: PropTypes.func,
+    onFinish: PropTypes.func,
+    scalesPageToFit: PropTypes.bool
   }
 
   constructor() {

--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
   "homepage": "https://github.com/Myagi/react-native-vimeo#readme",
   "peerDependencies": {
     "react-native-webview-bridge": "^0.20.3"
+  },
+  "dependencies": {
+    "prop-types": "^15.5.10"
   }
 }


### PR DESCRIPTION
Using prop-types dependency instead of React.PropType thus allowing to upgrade to RN 0.47